### PR TITLE
Introduce proto file patcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,84 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "pbuildrs"
 version = "0.1.0"
 dependencies = [
+ "rayon",
+ "tempfile",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -20,11 +94,53 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -39,19 +155,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.16"
+name = "tempfile"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -63,3 +191,37 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+rayon = { version = "1.11.0", default-features = false }
+tempfile = { version = "3.21.0", default-features = false }
 thiserror = { version = "2.0.16", default-features = false, features = ["std"] }
+walkdir = { version = "2.5.0", default-features = false }

--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -1,0 +1,712 @@
+use std::{cmp, io};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to read the input protobuf file: {0}")]
+    Read(io::Error),
+    #[error("Failed to write the output protobuf file: {0}")]
+    Write(io::Error),
+    #[error("Failed to parse the protobuf file: Invalid parser state encountered")]
+    InvalidState,
+}
+
+#[derive(cmp::PartialEq, Debug)]
+pub enum Outcome {
+    Untouched,
+    Replaced,
+}
+
+enum State {
+    None,
+    CommentPending(usize, CommentContext),
+    CommentSingleLine(usize, CommentContext),
+    CommentMultiLine(usize, CommentContext),
+    CommentMultiLineEndPending(usize, CommentContext),
+    Edition(usize, usize),
+    EditionWhitespacePost(usize),
+    EditionEqual(usize),
+    EditionEqualWhitespacePost(usize),
+    EditionOpenQuote(usize),
+    EditionValueEscape(usize),
+    EditionValue(usize),
+    EditionCloseQuote(usize),
+    Complete(Option<(usize, usize)>),
+}
+
+impl State {
+    fn next_token(self, ch: u8, pos: usize) -> Result<Self, Error> {
+        Ok(match self {
+            Self::Complete(_) => self,
+            Self::None => match ch {
+                b'e' => Self::Edition(pos, 0),
+                b'/' => Self::CommentPending(pos, self.try_into()?),
+                c if c.is_ascii_whitespace() => Self::None,
+                _ => Self::Complete(None),
+            },
+            Self::CommentPending(start_at, ctx) => match ch {
+                b'/' => Self::CommentSingleLine(start_at, ctx),
+                b'*' => Self::CommentMultiLine(start_at, ctx),
+                _ => Self::Complete(None),
+            },
+            Self::CommentSingleLine(start_at, ctx) => match ch {
+                b'\n' => ctx.into(),
+                _ => Self::CommentSingleLine(start_at, ctx),
+            },
+            Self::CommentMultiLine(start_at, ctx) => match ch {
+                b'*' => Self::CommentMultiLineEndPending(start_at, ctx),
+                _ => Self::CommentMultiLine(start_at, ctx),
+            },
+            Self::CommentMultiLineEndPending(start_at, ctx) => match ch {
+                b'/' => ctx.into(),
+                _ => Self::CommentMultiLine(start_at, ctx),
+            },
+            Self::Edition(start_at, idx) => match (idx, ch) {
+                (0, b'd') | (1, b'i') | (2, b't') | (3, b'i') | (4, b'o') | (5, b'n') => {
+                    Self::Edition(start_at, idx + 1)
+                }
+                (6, b'=') => Self::EditionEqual(start_at),
+                (6, b'/') => Self::CommentPending(start_at, self.try_into()?),
+                (6, c) if c.is_ascii_whitespace() => Self::EditionWhitespacePost(start_at),
+                _ => Self::Complete(None),
+            },
+            Self::EditionWhitespacePost(start_at) => match ch {
+                b'=' => Self::EditionEqual(start_at),
+                b'/' => Self::CommentPending(start_at, self.try_into()?),
+                c if c.is_ascii_whitespace() => Self::EditionWhitespacePost(start_at),
+                _ => Self::Complete(None),
+            },
+            Self::EditionEqual(start_at) | Self::EditionEqualWhitespacePost(start_at) => match ch {
+                b'"' => Self::EditionOpenQuote(start_at),
+                b'/' => Self::CommentPending(start_at, self.try_into()?),
+                c if c.is_ascii_whitespace() => Self::EditionEqualWhitespacePost(start_at),
+                _ => Self::Complete(None),
+            },
+            Self::EditionOpenQuote(start_at) | Self::EditionValue(start_at) => match ch {
+                b'"' => Self::EditionCloseQuote(start_at),
+                b'\\' => Self::EditionValueEscape(start_at),
+                _ => Self::EditionValue(start_at),
+            },
+            Self::EditionValueEscape(start_at) => Self::EditionValue(start_at),
+            Self::EditionCloseQuote(start_at) => Self::Complete(Some((start_at, pos))),
+        })
+    }
+
+    fn get_bounds(&self) -> Option<(usize, Option<usize>)> {
+        match self {
+            &Self::Complete(None) | Self::None => None,
+            &Self::Complete(Some((to, from))) => Some((to, Some(from))),
+            &Self::CommentPending(to, _)
+            | &Self::CommentSingleLine(to, _)
+            | &Self::CommentMultiLine(to, _)
+            | &Self::CommentMultiLineEndPending(to, _)
+            | &Self::Edition(to, _)
+            | &Self::EditionWhitespacePost(to)
+            | &Self::EditionEqual(to)
+            | &Self::EditionEqualWhitespacePost(to)
+            | &Self::EditionOpenQuote(to)
+            | &Self::EditionValueEscape(to)
+            | &Self::EditionValue(to)
+            | &Self::EditionCloseQuote(to) => Some((to, None)),
+        }
+    }
+}
+
+enum CommentContext {
+    None,
+    EditionWhitespacePost(usize),
+    EditionEqual(usize),
+    EditionEqualWhitespacePost(usize),
+}
+
+impl From<CommentContext> for State {
+    fn from(value: CommentContext) -> Self {
+        match value {
+            CommentContext::None => Self::None,
+            CommentContext::EditionWhitespacePost(pos) => Self::EditionWhitespacePost(pos),
+            CommentContext::EditionEqual(pos) => Self::EditionEqual(pos),
+            CommentContext::EditionEqualWhitespacePost(pos) => {
+                Self::EditionEqualWhitespacePost(pos)
+            }
+        }
+    }
+}
+
+impl TryFrom<State> for CommentContext {
+    type Error = Error;
+
+    fn try_from(value: State) -> Result<Self, Self::Error> {
+        match value {
+            State::None => Ok(Self::None),
+            State::EditionWhitespacePost(pos) => Ok(Self::EditionWhitespacePost(pos)),
+            State::EditionEqual(pos) => Ok(Self::EditionEqual(pos)),
+            State::EditionEqualWhitespacePost(pos) => Ok(Self::EditionEqualWhitespacePost(pos)),
+            State::Edition(pos, 6) => Ok(Self::EditionWhitespacePost(pos)),
+            _ => Err(Error::InvalidState),
+        }
+    }
+}
+
+pub fn patch_edition(mut src: impl io::BufRead, mut dst: impl io::Write) -> Result<Outcome, Error> {
+    let mut line = Vec::with_capacity(1 << 14);
+    // let mut line = Vec::with_capacity(30|29);
+    let mut state = State::None;
+    let mut outcome = Outcome::Untouched;
+
+    while src.read_until(b'\n', &mut line).map_err(Error::Read)? > 0 {
+        state = line
+            .iter()
+            .enumerate()
+            .try_fold(state, |state, (pos, &ch)| state.next_token(ch, pos))?;
+
+        match state.get_bounds() {
+            Some((to, Some(from))) => {
+                dst.write_all(&line[0..to]).map_err(Error::Write)?;
+                dst.write_all(r#"syntax = "proto3""#.as_bytes())
+                    .map_err(Error::Write)?;
+                dst.write_all(&line[from..]).map_err(Error::Write)?;
+
+                line.clear();
+
+                outcome = Outcome::Replaced;
+            }
+            Some((to, None)) => {
+                dst.write_all(&line[0..to]).map_err(Error::Write)?;
+
+                line.drain(0..to);
+            }
+            None => {
+                dst.write_all(&line).map_err(Error::Write)?;
+
+                line.clear();
+            }
+        }
+
+        state = match state {
+            State::Complete(Some(_)) => State::Complete(None),
+            State::Complete(None) => state,
+            _ => State::None,
+        };
+    }
+
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    #[test]
+    fn copy_unchanged() {
+        let input = r#"syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The output string is corrupted");
+
+        assert_eq!(input, output, "");
+    }
+
+    #[test]
+    fn copy_replace() {
+        let input = r#"edition = "2023";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax"
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_unchanged_ignoring_comments() {
+        let input = r#"// This is a comment above the edition
+syntax = "proto2";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"// This is a comment above the edition
+syntax = "proto2";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_ignoring_comments() {
+        let input = r#"/* This is a comment above the edition
+and it is a multi-line one */
+edition = "2023";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax"
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"/* This is a comment above the edition
+and it is a multi-line one */
+syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_unchanged_ignoring_whitespace() {
+        let input = r#"
+  syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"
+  syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_ignoring_whitespace() {
+        let input = r#"
+  edition = "2023";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax"
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"
+  syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_unchanged_ignoring_edition_inside_message() {
+        let input = r#"syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string edition = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string edition = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_ignore_same_line_comment() {
+        let input = r#"/* This is a weird case of the comment */ edition = "2023";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax"
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"/* This is a weird case of the comment */ syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_unchanged_ignoring_same_line_comment() {
+        let input = r#"/* This is a weird case of the comment */ syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"/* This is a weird case of the comment */ syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_unchanged_ignoring_edition_inside_comment() {
+        let input = r#"/* We can't yet upgrade to the
+edition = "2023";
+because not every language compiler supports it.*/
+syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Untouched,
+            outcome,
+            "Expected the file to be copied without changes",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"/* We can't yet upgrade to the
+edition = "2023";
+because not every language compiler supports it.*/
+syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_ignoring_edition_inside_comment() {
+        let input = r#"/* We recently upgraded to the
+edition = "2023";
+* but we have tooling that replaces it back to
+syntax = "proto3";
+on as needed basis for languages that don't have proper support */
+edition = "2023";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"/* We recently upgraded to the
+edition = "2023";
+* but we have tooling that replaces it back to
+syntax = "proto3";
+on as needed basis for languages that don't have proper support */
+syntax = "proto3";
+
+package crabs;
+
+message Ferris {
+  string type = 1;
+}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_no_whitespace_in_edition() {
+        let input = r#"edition="2023";
+
+package crabs;
+
+message Ferris {}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"syntax = "proto3";
+
+package crabs;
+
+message Ferris {}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_multiple_whitespace_in_edition() {
+        let input = r#"edition =		"2023" ;
+
+package crabs;
+
+message Ferris {}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"syntax = "proto3" ;
+
+package crabs;
+
+message Ferris {}
+"#,
+            output,
+        );
+    }
+
+    #[test]
+    fn copy_replace_with_comments_in_edition() {
+        let input = r#"edition/* Edition comment */// Weird comment here
+= /*This may be 2024 at some point*/"2023"
+// Needs to be replaced with syntax for now tho.
+;
+
+package crabs;
+
+message Ferris {}
+"#;
+
+        let mut output = Vec::new();
+        let result = super::patch_edition(io::BufReader::new(input.as_bytes()), &mut output);
+        let outcome = result.expect("Faled to copy the data");
+
+        assert_eq!(
+            super::Outcome::Replaced,
+            outcome,
+            "Expected the edition to be replaced with syntax",
+        );
+
+        let output = String::from_utf8(output).expect("The resulting copy is corrupted");
+
+        assert_eq!(
+            r#"syntax = "proto3"
+// Needs to be replaced with syntax for now tho.
+;
+
+package crabs;
+
+message Ferris {}
+"#,
+            output,
+        );
+    }
+}


### PR DESCRIPTION
Provide a new implementation for the file-based protobuf patcher, building on top of the previous in-memory only implementation. This is required as we need to be able to generate Protobuf files that can be read and processed by the Protobuf compiler, so pure in-memory implementation is not sufficient.

The new implementation utilizes the [rayon](https://crates.io/crates/rayon) crate for parallel file processing. The original in-memory patching implementation was moved from the `lib.rs` file into its own module.