### PR TITLE
Configure dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @software-artificer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule: 
+    interval: "weekly"
+    day: "saturday"
+    time: "04:00"
+    timezone: "Australia/Sydney"
+- package-ecosystem: "cargo"
+  directory: "/"
+  schedule: 
+    interval: "weekly"
+    day: "saturday"
+    time: "04:00"
+    timezone: "Australia/Sydney"


### PR DESCRIPTION
Set-up dependabot to check for GitHub Actions and Cargo dependency updates every Saturday at 4am Sydney time.