### PR TITLE
Provide CLI binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+    - uses: arduino/setup-protoc@v3
     - name: Run the test suite
       run: cargo test --all-features
-  linting:
+
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +40,44 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "crossbeam-deque"
@@ -177,6 +221,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "pbuildrs"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "rayon",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.45", default-features = false, features = ["derive", "help", "std"] }
 rayon = { version = "1.11.0", default-features = false }
 tempfile = { version = "3.21.0", default-features = false }
 thiserror = { version = "2.0.16", default-features = false, features = ["std"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,13 +2,30 @@ use std::{fs, io, path};
 
 use crate::modgen;
 
+/// Compile protobuf files into properly structured Rust code with modules using the Prost compiler.
+#[derive(clap::Parser)]
+#[command(about)]
 pub struct Args {
+    /// Whether to generate the gRPC client code
+    #[arg(long, default_value_t = false)]
     build_client: bool,
+    /// Whether to generate the gRPC server stubs
+    #[arg(long, default_value_t = false)]
     build_server: bool,
-    with_well_known_type: bool,
+    /// Specify whether to build the well-known types
+    #[arg(long, default_value_t = false)]
+    with_well_known_types: bool,
+    /// Add a directory to the Protobuf import path (can be specified multiple times)
+    #[arg(long, short = 'I')]
     include_path: Vec<path::PathBuf>,
+    /// Specify the output path for the compiled files
+    #[arg(long, default_value = "out")]
     output: path::PathBuf,
+    /// Specify the source path of the protobuf files to compile
+    #[arg(long, default_value = "proto")]
     source: path::PathBuf,
+    /// Specify a path where to create a temporary working directory
+    #[arg(long)]
     temp_dir: Option<path::PathBuf>,
 }
 
@@ -78,7 +95,7 @@ pub fn run(args: Args) -> Result<(), Error> {
         .build_client(args.build_client)
         .build_server(args.build_server)
         .build_transport(args.build_client || args.build_server)
-        .compile_well_known_types(args.with_well_known_type)
+        .compile_well_known_types(args.with_well_known_types)
         .out_dir(&compiled_files_dir)
         .compile_protos(&patched_files, &includes)
         .map_err(Error::CompileProto)?;
@@ -101,7 +118,7 @@ mod tests {
         let args = super::Args {
             build_client: true,
             build_server: true,
-            with_well_known_type: true,
+            with_well_known_types: true,
             include_path: vec![],
             output: dst.path().to_owned(),
             source: src,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use pbuildrs::cli;
+use std::process;
+
+fn main() {
+    let args = cli::Args::parse();
+
+    if let Err(e) = pbuildrs::cli::run(args) {
+        eprintln!("{e}");
+
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
Introduce a main CLI binary that can take command line arguments and feed them into the CLI handler to compile protobuf files. This is going to be the main program entrypoint.