### PR TITLE
Update argument parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         toolchain: stable
     - uses: arduino/setup-protoc@v3
     - name: Use pbuildrs to compile protobuf IDL
-      run: cargo run -- --build-client --build-server --with-well-known-types --source proto/ --output example/src/autogen/
+      run: cargo run -- --build-client --build-server --with-well-known-types ./proto/ --output example/src/autogen/
     - name: Verify that generated code actually works
       run: cargo test
       working-directory: example/

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,12 +21,12 @@ pub struct Args {
     /// Specify the output path for the compiled files
     #[arg(long, default_value = "out")]
     output: path::PathBuf,
-    /// Specify the source path of the protobuf files to compile
-    #[arg(long, default_value = "proto")]
-    source: path::PathBuf,
     /// Specify a path where to create a temporary working directory
     #[arg(long)]
     temp_dir: Option<path::PathBuf>,
+    /// Specify the source path of the protobuf files to compile
+    #[arg()]
+    source: path::PathBuf,
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Drop the `--source` flag and instead take a single mandatory argument that represents the path to the directory containing protobuf definitions. This makes experience a bit more intuitive.