### PR TITLE
Set a proper tag name for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,8 @@ jobs:
         name: x86_64-linux
     - name: Create a GitHub release
       run: |
-        gh release create --draft --generate-notes --prerelease \
-          --title "Release ${{ github.ref_name }} draft" \
+        gh release create ${{ github.ref_name }}--draft --generate-notes
+          --prerelease --title "Release ${{ github.ref_name }} draft" \
           --repo software-artificer/pbuildrs \
           "pbuildrs-${{ github.ref_name }}-aarch64-darwin.zip" \
           "pbuildrs-${{ github.ref_name }}-x86_64-linux.tar.bz2"


### PR DESCRIPTION
Make sure that the `gh release` command uses a correct tag name.