### PR TITLE
Fix the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         name: x86_64-linux
     - name: Create a GitHub release
       run: |
-        gh release create ${{ github.ref_name }}--draft --generate-notes
+        gh release create ${{ github.ref_name }} --draft --generate-notes \
           --prerelease --title "Release ${{ github.ref_name }} draft" \
           --repo software-artificer/pbuildrs \
           "pbuildrs-${{ github.ref_name }}-aarch64-darwin.zip" \


### PR DESCRIPTION
Fix the `gh release` command. Make sure that the passed tag has a space after so it doesn't merge with the `--draft` flag. Make sure that we escape line break for the bash command.