### PR TITLE
Use repo name from context in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         gh release create ${{ github.ref_name }} --draft --generate-notes \
           --prerelease --title "Release ${{ github.ref_name }} draft" \
-          --repo software-artificer/pbuildrs \
+          --repo "${{ github.repository }}" \
           "pbuildrs-${{ github.ref_name }}-aarch64-darwin.zip" \
           "pbuildrs-${{ github.ref_name }}-x86_64-linux.tar.bz2"
       env:


### PR DESCRIPTION
Instead of having a hardcoded repository name in the release GitHub workflow use the GitHub context to obtain it dynamically. This ensures the release process works reliably, regardless if the repository is renamed.