### PR TITLE
Guard client and server code behind features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
     - name: Use pbuildrs to compile protobuf IDL
       run: cargo run -- --build-client --build-server --with-well-known-types ./proto/ --output example/src/autogen/
     - name: Verify that generated code actually works
-      run: cargo test
+      run: cargo test --all-features
       working-directory: example/

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -3,10 +3,14 @@ name = "example"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+client = ["dep:tonic", "dep:tonic-prost"]
+server = ["dep:tonic", "dep:tonic-prost"]
+
 [dependencies]
 prost = { version = "0.14.1", default-features = false, features = ["derive"] }
-tonic = { version = "0.14.2", default-features = false, features = ["codegen", "transport"] }
-tonic-prost = { version = "0.14.2", default-features = false }
+tonic = { version = "0.14.2", default-features = false, features = ["codegen", "transport"], optional = true }
+tonic-prost = { version = "0.14.2", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.47.1", default-features = false, features = ["rt-multi-thread"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,7 +93,9 @@ pub fn run(args: Args) -> Result<(), Error> {
 
     tonic_prost_build::configure()
         .build_client(args.build_client)
+        .client_mod_attribute(".", r#"#[cfg(feature = "client")]"#)
         .build_server(args.build_server)
+        .server_mod_attribute(".", r#"#[cfg(feature = "server")]"#)
         .build_transport(args.build_client || args.build_server)
         .compile_well_known_types(args.with_well_known_types)
         .out_dir(&compiled_files_dir)


### PR DESCRIPTION
Sometimes, it is useful to include just the generated protobuf messages, without any server or client stubs. In other cases, clients only care about client code and servers care about server. Adding features that provide granular control whether client or server code should be enabled, also both or neither.