### PR TITLE
Use GitHub token for arduino/setup-protoc action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,45 +8,65 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v6
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+
     - uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Run the test suite
       run: cargo test --all-features
 
   lint:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v6
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
         components: clippy, rustfmt
+
     - name: Run clippy linter
       run: cargo clippy --all-targets
+
     - name: Run formatter
       run: cargo fmt --check
+
   build:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v6
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+
     - name: Run the build
       run: cargo build
 
   verify:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v6
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+
     - uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Use pbuildrs to compile protobuf IDL
       run: |
         cargo run -- --build-client --build-server --with-well-known-types \


### PR DESCRIPTION
Use `secrets.GITHUB_TOKEN` for `arduion/setup-protoc` action so it doesn't hit API rate limits.